### PR TITLE
Fix readability score formatting in rewrite agent

### DIFF
--- a/webrenewal/agents/rewrite.py
+++ b/webrenewal/agents/rewrite.py
@@ -26,7 +26,11 @@ class RewriteAgent(Agent[tuple[ContentExtract, RenewalPlan], ContentBundle]):
                 "This content was refreshed to emphasise the clinic's benefits and clarity. "
                 "Original readability score: "
             )
-            refreshed = f"{intro}{section.readability_score:.1f if section.readability_score is not None else 'n/a'}.\n\n{section.text}"
+            if section.readability_score is not None:
+                readability_score = f"{section.readability_score:.1f}"
+            else:
+                readability_score = "n/a"
+            refreshed = f"{intro}{readability_score}.\n\n{section.text}"
             blocks.append(
                 ContentBlock(
                     title=section.title or f"Section {index}",


### PR DESCRIPTION
## Summary
- handle missing readability scores when formatting refreshed content

## Testing
- python -m compileall webrenewal/agents/rewrite.py

------
https://chatgpt.com/codex/tasks/task_e_68dba8960778832d89f820d4e5bfc2c4