### PR TITLE
Handle legacy OpenAI responses client

### DIFF
--- a/tests/test_rewrite_agent.py
+++ b/tests/test_rewrite_agent.py
@@ -1,3 +1,4 @@
+import json
 import sys
 import unittest
 from types import SimpleNamespace
@@ -10,6 +11,24 @@ class _DummyOpenAIError(Exception):
 class _DummyOpenAI:
     def __init__(self, *args, **kwargs):  # pragma: no cover - simple stub
         pass
+
+
+class _LegacyResponses:
+    def __init__(self, payload):
+        self._payload = payload
+        self.calls = []
+
+    def create(self, **kwargs):  # pragma: no cover - behaviour tested indirectly
+        self.calls.append(kwargs)
+        if len(self.calls) == 1 and "response_format" in kwargs:
+            raise TypeError("create() got an unexpected keyword argument 'response_format'")
+
+        return SimpleNamespace(output_text=json.dumps(self._payload))
+
+
+class _LegacyClient:
+    def __init__(self, payload):
+        self.responses = _LegacyResponses(payload)
 
 
 if "openai" not in sys.modules:
@@ -78,6 +97,28 @@ class RewriteAgentTests(unittest.TestCase):
         self.assertEqual(captured.get("domain"), "example.com")
         self.assertIs(captured.get("content"), self.content)
         self.assertIs(captured.get("plan"), self.plan)
+
+    def test_retry_without_response_format_when_unsupported(self) -> None:
+        payload = {
+            "meta_title": "Example Site",
+            "meta_description": "Description",
+            "blocks": [
+                {"title": "Welcome", "body": "New welcome copy."},
+                {"title": "Services", "body": "Updated services details."},
+            ],
+        }
+
+        agent = RewriteAgent()
+        legacy_client = _LegacyClient(payload)
+        agent._get_client = lambda: legacy_client  # type: ignore[assignment]
+
+        bundle = agent.run(("example.com", self.content, self.plan))
+
+        self.assertFalse(bundle.fallback_used)
+        self.assertEqual(len(legacy_client.responses.calls), 2)
+        self.assertIn("response_format", legacy_client.responses.calls[0])
+        self.assertNotIn("response_format", legacy_client.responses.calls[1])
+        self.assertEqual(bundle.blocks[0].body, "New welcome copy.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add compatibility retry when the OpenAI Responses client rejects the response_format keyword
- ensure fallback calls still yield JSON output for parsing
- cover the legacy behaviour with a regression test using a stubbed client

## Testing
- PYTHONPATH=. pytest tests/test_rewrite_agent.py

------
https://chatgpt.com/codex/tasks/task_e_68dbc11c0cfc832d991d9c299ebca73f