### PR TITLE
Improve logging detail for debugging failures

### DIFF
--- a/webrenewal/agents/crawler.py
+++ b/webrenewal/agents/crawler.py
@@ -40,7 +40,9 @@ class CrawlerAgent(Agent[ScopePlan, CrawlResult]):
             try:
                 response = get(current_url, headers={"User-Agent": "AgenticWebRenewal/0.1"})
             except requests.RequestException as exc:  # type: ignore[attr-defined]
-                self.logger.error("Failed to fetch %s: %s", current_url, exc)
+                self.logger.error(
+                    "Failed to fetch %s: %s", current_url, exc, exc_info=True
+                )
                 continue
             pages.append(
                 PageContent(

--- a/webrenewal/agents/rewrite.py
+++ b/webrenewal/agents/rewrite.py
@@ -38,7 +38,9 @@ class RewriteAgent(Agent[RewriteInput, ContentBundle]):
         try:
             return self._rewrite_with_llm(client, domain, content, plan)
         except (OpenAIError, ValueError, json.JSONDecodeError) as exc:
-            self.logger.warning("LLM rewrite failed (%s); using fallback", exc)
+            self.logger.warning(
+                "LLM rewrite failed (%s); using fallback", exc, exc_info=True
+            )
             return self._fallback_bundle(domain, content)
 
     def _normalise_input(

--- a/webrenewal/agents/scope.py
+++ b/webrenewal/agents/scope.py
@@ -26,7 +26,7 @@ class ScopeAgent(Agent[str, ScopePlan]):
         try:
             response = get(robots_url)
         except requests.RequestException as exc:  # type: ignore[attr-defined]
-            self.logger.warning("Failed to fetch robots.txt: %s", exc)
+            self.logger.warning("Failed to fetch robots.txt: %s", exc, exc_info=True)
             return None
         if response.status_code >= 400:
             self.logger.info("Robots.txt not available at %s", robots_url)

--- a/webrenewal/logging_config.py
+++ b/webrenewal/logging_config.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 
 _LOG_FORMAT = (
-    "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+    "%(asctime)s | %(levelname)s | %(name)s | %(pathname)s:%(lineno)d | %(funcName)s | %(message)s"
 )
 
 


### PR DESCRIPTION
## Summary
- include file path, line number, and function name in the default log formatter to expose calling context
- log caught exceptions with stack traces in the scope, crawler, and rewrite agents so warning and error messages capture root causes

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'webrenewal')*

------
https://chatgpt.com/codex/tasks/task_e_68dbc9124434832dad278db2bfe5e54e