### PR TITLE
Improve structured logging consistency

### DIFF
--- a/webrenewal/agents/tool_discovery.py
+++ b/webrenewal/agents/tool_discovery.py
@@ -4,8 +4,11 @@ from __future__ import annotations
 
 from typing import Iterable
 
+import logging
+
 from .base import Agent
 from ..models import ToolCatalog, ToolInfo
+from ..tracing import log_event
 
 
 class ToolDiscoveryAgent(Agent[None, ToolCatalog]):
@@ -15,7 +18,12 @@ class ToolDiscoveryAgent(Agent[None, ToolCatalog]):
         super().__init__(name="A0.ToolDiscovery")
 
     def run(self, data: None = None) -> ToolCatalog:  # type: ignore[override]
-        self.logger.info("Compiling tool catalog")
+        log_event(
+            self.logger,
+            logging.INFO,
+            "tool_discovery.start",
+            agent=self.name,
+        )
         tools: Iterable[ToolInfo] = [
             ToolInfo(
                 name="@playwright/mcp",
@@ -43,7 +51,13 @@ class ToolDiscoveryAgent(Agent[None, ToolCatalog]):
             ),
         ]
         catalog = ToolCatalog(tools=list(tools))
-        self.logger.debug("Generated tool catalog with %d entries", len(catalog.tools))
+        log_event(
+            self.logger,
+            logging.DEBUG,
+            "tool_discovery.finish",
+            agent=self.name,
+            tools=len(catalog.tools),
+        )
         return catalog
 
 

--- a/webrenewal/pipeline.py
+++ b/webrenewal/pipeline.py
@@ -208,13 +208,32 @@ class WebRenewalPipeline:
             "class": agent.__class__.__name__,
         }
 
+        log_event(
+            self.logger,
+            logging.INFO,
+            "agent.start",
+            **metadata,
+        )
+
         with trace(f"{agent_label}.run", logger=self.logger, **metadata):
-            result = agent.run(payload)
+            try:
+                result = agent.run(payload)
+            except Exception as exc:
+                log_event(
+                    self.logger,
+                    logging.ERROR,
+                    "agent.error",
+                    **metadata,
+                    error=str(exc),
+                    exception=exc.__class__.__name__,
+                    exc_info=True,
+                )
+                raise
 
         log_event(
             self.logger,
             logging.INFO,
-            "agent.result",
+            "agent.finish",
             **metadata,
             summary=self._summarise_output(result),
         )


### PR DESCRIPTION
## Summary
- add explicit start, finish, and error events around each agent execution
- convert crawler, scope, and tool discovery agents to structured JSON logs with clearer metadata
- normalise rewrite agent debug/error logging for consistent plain-text error details

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'webrenewal')*

------
https://chatgpt.com/codex/tasks/task_e_68dcf5da5af8832d9812d90a161e60ee