### PR TITLE
Refactor LLM layer with tracing and MCP support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,13 @@ dependencies = [
     "python-dotenv>=1.0.1",
     "httpx>=0.27.0",
     "anthropic>=0.34.0",
+    "jsonschema>=4.21.1",
+    "mcp>=1.15.0",
 ]
 
 [project.scripts]
 renewal = "renewal:main"
+llm-mcp = "webrenewal.llm.mcp_server:main"
 
 [tool.pytest.ini_options]
 pythonpath = ["."]

--- a/renewal.py
+++ b/renewal.py
@@ -27,7 +27,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--llm",
         default=os.getenv("LLM_PROVIDER", "openai"),
-        choices=["openai", "ollama", "anthropic"],
+        choices=["openai", "ollama", "anthropic", "gemini", "deepseek", "groq"],
         help="Choose the LLM provider backend (default: env LLM_PROVIDER or openai).",
     )
     parser.add_argument(

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ openai>=1.51.0
 python-dotenv>=1.0.1
 httpx>=0.27.0
 anthropic>=0.34.0
+jsonschema>=4.21.1
+mcp>=1.15.0

--- a/tests/unit/agents/test_rewrite_agent.py
+++ b/tests/unit/agents/test_rewrite_agent.py
@@ -1,59 +1,91 @@
-"""Tests for :class:`webrenewal.agents.rewrite.RewriteAgent`."""
-
 from __future__ import annotations
 
 import json
-from typing import Any, Dict, Iterable, List
+from dataclasses import dataclass
+from typing import Any, Dict, List, Sequence, Tuple
 
 import pytest
 
 from webrenewal.agents.rewrite import RewriteAgent
-from webrenewal.llm import LLMResponse
-from webrenewal.models import ContentBundle, ContentExtract, ContentSection, RenewalAction, RenewalPlan
+from webrenewal.llm import LLMService, get_tracer
+from webrenewal.llm.clients import LLMClient, ProviderResponse
+from webrenewal.models import (
+    ContentBundle,
+    ContentExtract,
+    ContentSection,
+    RenewalAction,
+    RenewalPlan,
+)
 
 
-class StubLLMClient:
-    """Deterministic LLM client returning queued payloads."""
+class StubLLMProvider(LLMClient):
+    """Return queued JSON payloads for rewrite tests."""
 
-    def __init__(self, payloads: List[Dict[str, Any]]) -> None:
-        self._payloads = payloads
+    def __init__(self, payloads: Sequence[Dict[str, Any]]) -> None:
+        self._payloads = list(payloads)
         self.calls: List[Dict[str, Any]] = []
-        self._index = 0
 
-    async def complete_json(self, messages: Iterable[Dict[str, Any]], *, model: str, temperature: float | None = None) -> LLMResponse:  # noqa: D401 - async stub
-        self.calls.append({"messages": list(messages), "model": model, "temperature": temperature})
-        payload = self._payloads[self._index]
-        self._index += 1
-        return LLMResponse(text=json.dumps(payload), data=payload)
+    async def _complete(
+        self,
+        messages: Sequence[Dict[str, Any]],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        self.calls.append(
+            {
+                "messages": list(messages),
+                "model": model,
+                "temperature": temperature,
+                "response_format": response_format,
+            }
+        )
+        payload = self._payloads.pop(0)
+        return ProviderResponse(text=json.dumps(payload))
 
 
-class ErrorLLMClient:
-    async def complete_json(self, *args, **kwargs) -> LLMResponse:  # noqa: D401 - async stub
-        raise ValueError("boom")
+@dataclass
+class ErrorProvider(LLMClient):
+    """Client raising an exception for every call."""
+
+    exception: Exception
+
+    async def _complete(
+        self,
+        messages: Sequence[Dict[str, Any]],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        raise self.exception
 
 
 @pytest.fixture
 def rewrite_agent_payloads() -> List[Dict[str, Any]]:
-    """Return payloads for the stub LLM client representing block rewrites."""
-
     return [
         {
             "meta_title": "Example Site",
             "meta_description": "Description",
-            "blocks": [{"title": "Welcome", "body": "New welcome copy."}],
+            "blocks": [{"title": "Welcome", "body": "New welcome copy.", "type": "text"}],
         },
         {
             "meta_title": None,
             "meta_description": None,
-            "blocks": [{"title": "Services", "body": "Updated services details."}],
+            "blocks": [
+                {
+                    "title": "Services",
+                    "body": "Updated services details.",
+                    "type": "text",
+                }
+            ],
         },
     ]
 
 
 @pytest.fixture
 def legacy_content() -> ContentExtract:
-    """Return sample content sections used by the rewrite agent tests."""
-
     sections = [
         ContentSection(title="Welcome", text="Hello world", readability_score=65.2),
         ContentSection(title="Services", text="We offer things", readability_score=70.1),
@@ -63,8 +95,6 @@ def legacy_content() -> ContentExtract:
 
 @pytest.fixture
 def renewal_plan() -> RenewalPlan:
-    """Return a plan with a single action for rewrite prompts."""
-
     return RenewalPlan(
         goals=["Improve clarity"],
         actions=[
@@ -79,9 +109,15 @@ def renewal_plan() -> RenewalPlan:
     )
 
 
-def test_rewrite_agent_fallback_without_client(legacy_content: ContentExtract, renewal_plan: RenewalPlan) -> None:
-    """Given legacy input tuple When no LLM client is configured Then fallback bundle is produced."""
+def build_service(payloads: Sequence[Dict[str, Any]]) -> Tuple[LLMService, StubLLMProvider]:
+    provider = StubLLMProvider(payloads)
+    service = LLMService(provider="stub", client=provider, tracer=get_tracer())
+    return service, provider
 
+
+def test_rewrite_agent_fallback_without_client(
+    legacy_content: ContentExtract, renewal_plan: RenewalPlan
+) -> None:
     agent = RewriteAgent()
     agent._get_client = lambda: None  # type: ignore[assignment]
 
@@ -97,23 +133,22 @@ def test_rewrite_agent_threads_domain_into_prompts(
     legacy_content: ContentExtract,
     renewal_plan: RenewalPlan,
 ) -> None:
-    """Given domain-aware tuples When rewriting Then prompts mention the requested domain."""
-
-    stub = StubLLMClient(rewrite_agent_payloads)
-    agent = RewriteAgent(llm_client=stub, model="test-model", max_parallel_requests=2)
+    service, provider = build_service(rewrite_agent_payloads)
+    agent = RewriteAgent(llm_client=service, model="test-model", max_parallel_requests=2)
 
     bundle = agent.run(("example.com", legacy_content, renewal_plan))
 
     assert bundle.fallback_used is False
     assert len(bundle.blocks) == len(legacy_content.sections)
-    first_messages = stub.calls[0]["messages"]
-    assert any("example.com" in message["content"] for message in first_messages)
+    first_call = provider.calls[0]
+    assert any("example.com" in message["content"] for message in first_call["messages"])
 
 
-def test_rewrite_agent_handles_llm_failures(legacy_content: ContentExtract, renewal_plan: RenewalPlan) -> None:
-    """Given LLM exceptions When rewriting Then fallback bundle is returned with safe defaults."""
-
-    agent = RewriteAgent(llm_client=ErrorLLMClient())
+def test_rewrite_agent_handles_llm_failures(
+    legacy_content: ContentExtract, renewal_plan: RenewalPlan
+) -> None:
+    service = LLMService(provider="stub", client=ErrorProvider(exception=ValueError("boom")), tracer=get_tracer())
+    agent = RewriteAgent(llm_client=service)
 
     bundle = agent.run(("example.com", legacy_content, renewal_plan))
 
@@ -121,9 +156,9 @@ def test_rewrite_agent_handles_llm_failures(legacy_content: ContentExtract, rene
     assert len(bundle.blocks) == len(legacy_content.sections)
 
 
-def test_rewrite_agent_normalise_input_validates_tuple(legacy_content: ContentExtract, renewal_plan: RenewalPlan) -> None:
-    """Given unexpected tuple sizes When normalising Then ValueError is raised."""
-
+def test_rewrite_agent_normalise_input_validates_tuple(
+    legacy_content: ContentExtract, renewal_plan: RenewalPlan
+) -> None:
     agent = RewriteAgent()
 
     with pytest.raises(ValueError):
@@ -131,10 +166,7 @@ def test_rewrite_agent_normalise_input_validates_tuple(legacy_content: ContentEx
 
 
 def test_rewrite_agent_normalise_input_type_checks() -> None:
-    """Given incorrect types When normalising Then TypeError is raised."""
-
     agent = RewriteAgent()
 
     with pytest.raises(TypeError):
         agent._normalise_input(("domain", object(), object()))  # type: ignore[arg-type]
-

--- a/webrenewal/llm/clients.py
+++ b/webrenewal/llm/clients.py
@@ -1,0 +1,390 @@
+"""Provider specific client implementations for LLM interactions."""
+
+from __future__ import annotations
+
+import abc
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence
+
+import httpx
+
+from .models import Message, TokenUsage
+
+
+MessagePayload = MutableMapping[str, Any]
+
+
+def _normalise_messages(messages: Iterable[MessagePayload]) -> List[Dict[str, Any]]:
+    normalised: List[Dict[str, Any]] = []
+    for message in messages:
+        role = str(message.get("role", "user"))
+        content = message.get("content", "")
+        if isinstance(content, (dict, list)):
+            serialised = json.dumps(content, ensure_ascii=False)
+        else:
+            serialised = str(content)
+        normalised.append({"role": role, "content": serialised})
+    return normalised
+
+
+@dataclass
+class ProviderResponse:
+    """Normalised response from a provider."""
+
+    text: str
+    raw: Any | None = None
+    usage: TokenUsage | None = None
+
+
+class LLMClient(abc.ABC):
+    """Interface for provider specific clients."""
+
+    async def complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None = None,
+        response_format: str | None = None,
+    ) -> ProviderResponse:
+        return await self._complete(
+            messages,
+            model=model,
+            temperature=temperature,
+            response_format=response_format,
+        )
+
+    @abc.abstractmethod
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        raise NotImplementedError
+
+
+class OpenAIClient(LLMClient):
+    """Adapter around the official OpenAI SDK."""
+
+    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+        from openai import AsyncOpenAI
+
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._client = AsyncOpenAI(**client_kwargs)
+
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        request: Dict[str, Any] = {"model": model, "input": _normalise_messages(messages)}
+        if temperature is not None:
+            request["temperature"] = temperature
+        if response_format == "json_object":
+            request["response_format"] = {"type": "json_object"}
+
+        response = await self._client.responses.create(**request)
+        text = getattr(response, "output_text", None)
+        if not text:
+            parts: List[str] = []
+            for item in getattr(response, "output", []) or []:
+                for content_item in getattr(item, "content", []) or []:
+                    text_value = getattr(content_item, "text", None)
+                    if isinstance(text_value, str) and text_value.strip():
+                        parts.append(text_value)
+                    json_value = getattr(content_item, "json", None)
+                    if isinstance(json_value, dict):
+                        parts.append(json.dumps(json_value))
+            text = "".join(parts)
+
+        if not text:
+            raise ValueError("OpenAI returned an empty response")
+
+        usage = None
+        usage_obj = getattr(response, "usage", None)
+        if usage_obj is not None:
+            usage = TokenUsage(
+                prompt_tokens=getattr(usage_obj, "prompt_tokens", None),
+                completion_tokens=getattr(usage_obj, "completion_tokens", None),
+                total_tokens=getattr(usage_obj, "total_tokens", None),
+            )
+
+        return ProviderResponse(text=text, raw=response, usage=usage)
+
+
+class AnthropicClient(LLMClient):
+    """Adapter around Anthropic's SDK."""
+
+    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+        from anthropic import AsyncAnthropic
+
+        client_kwargs: Dict[str, Any] = {"api_key": api_key}
+        if base_url:
+            client_kwargs["base_url"] = base_url
+        self._client = AsyncAnthropic(**client_kwargs)
+
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        normalised = _normalise_messages(messages)
+        system_messages = [m["content"] for m in normalised if m["role"] == "system"]
+        user_messages = [m for m in normalised if m["role"] != "system"]
+
+        request: Dict[str, Any] = {"model": model, "messages": user_messages}
+        if system_messages:
+            request["system"] = "\n\n".join(system_messages)
+        if temperature is not None:
+            request["temperature"] = temperature
+        if response_format == "json_object":
+            request["response_format"] = {"type": "json_object"}
+
+        response = await self._client.messages.create(**request)
+        parts: List[str] = []
+        for item in getattr(response, "content", []) or []:
+            text_value = getattr(item, "text", None)
+            if isinstance(text_value, str) and text_value.strip():
+                parts.append(text_value)
+        text = "".join(parts)
+        if not text:
+            raise ValueError("Anthropic returned an empty response")
+
+        usage = None
+        usage_obj = getattr(response, "usage", None)
+        if usage_obj is not None:
+            usage = TokenUsage(
+                prompt_tokens=getattr(usage_obj, "input_tokens", None),
+                completion_tokens=getattr(usage_obj, "output_tokens", None),
+                total_tokens=getattr(usage_obj, "total_tokens", None),
+            )
+
+        return ProviderResponse(text=text, raw=response, usage=usage)
+
+
+class OllamaClient(LLMClient):
+    """HTTP adapter for Ollama."""
+
+    def __init__(self, *, host: str, timeout: float = 60.0) -> None:
+        self._host = host.rstrip("/")
+        self._timeout = timeout
+
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        payload: Dict[str, Any] = {
+            "model": model,
+            "messages": _normalise_messages(messages),
+            "stream": False,
+        }
+        options: Dict[str, Any] = {}
+        if temperature is not None:
+            options["temperature"] = temperature
+        if response_format == "json_object":
+            options["format"] = "json"
+        if options:
+            payload["options"] = options
+
+        async with httpx.AsyncClient(base_url=self._host, timeout=self._timeout) as http:
+            response = await http.post("/api/chat", json=payload)
+            response.raise_for_status()
+            data = response.json()
+
+        message = data.get("message", {}) if isinstance(data, dict) else {}
+        content = message.get("content", "")
+        if isinstance(content, list):
+            text = "".join(
+                str(part.get("text", "")) for part in content if isinstance(part, dict)
+            )
+        else:
+            text = str(content)
+
+        if not text:
+            raise ValueError("Ollama returned an empty response")
+
+        eval_count = data.get("eval_count") if isinstance(data, dict) else None
+        usage = None
+        if isinstance(eval_count, int):
+            usage = TokenUsage(completion_tokens=eval_count)
+
+        return ProviderResponse(text=text, raw=data, usage=usage)
+
+
+class GeminiClient(LLMClient):
+    """HTTP client for Google Gemini."""
+
+    def __init__(self, *, api_key: str, base_url: str | None = None, timeout: float = 60.0) -> None:
+        self._api_key = api_key
+        self._base_url = (base_url or "https://generativelanguage.googleapis.com/v1beta").rstrip("/")
+        self._timeout = timeout
+
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        contents = [
+            {"role": message.get("role", "user"), "parts": [{"text": str(message.get("content", ""))}]}
+            for message in messages
+        ]
+
+        body: Dict[str, Any] = {"contents": contents}
+        if temperature is not None:
+            body.setdefault("generationConfig", {})["temperature"] = temperature
+        if response_format == "json_object":
+            body.setdefault("generationConfig", {})["responseMimeType"] = "application/json"
+
+        url = f"{self._base_url}/models/{model}:generateContent"
+        params = {"key": self._api_key}
+
+        async with httpx.AsyncClient(timeout=self._timeout) as http:
+            response = await http.post(url, params=params, json=body)
+            response.raise_for_status()
+            data = response.json()
+
+        candidates = data.get("candidates") if isinstance(data, dict) else None
+        if not candidates:
+            raise ValueError("Gemini returned an empty response")
+        first = candidates[0] or {}
+        content = first.get("content", {})
+        parts = content.get("parts", []) if isinstance(content, dict) else []
+        text = "".join(str(part.get("text", "")) for part in parts if isinstance(part, dict))
+        if not text:
+            raise ValueError("Gemini returned an empty response")
+
+        usage = None
+        usage_data = data.get("usageMetadata") if isinstance(data, dict) else None
+        if isinstance(usage_data, dict):
+            usage = TokenUsage(
+                prompt_tokens=usage_data.get("promptTokenCount"),
+                completion_tokens=usage_data.get("candidatesTokenCount"),
+                total_tokens=usage_data.get("totalTokenCount"),
+            )
+
+        return ProviderResponse(text=text, raw=data, usage=usage)
+
+
+class OpenAICompatibleClient(LLMClient):
+    """Generic HTTP client for OpenAI compatible chat APIs."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str,
+        api_key: str,
+        timeout: float = 60.0,
+        headers: Optional[Dict[str, str]] = None,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._api_key = api_key
+        self._timeout = timeout
+        self._headers = headers or {}
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers = {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
+        headers.update(self._headers)
+        return headers
+
+    async def _complete(
+        self,
+        messages: Sequence[MessagePayload],
+        *,
+        model: str,
+        temperature: float | None,
+        response_format: str | None,
+    ) -> ProviderResponse:
+        payload: Dict[str, Any] = {
+            "model": model,
+            "messages": _normalise_messages(messages),
+            "stream": False,
+        }
+        if temperature is not None:
+            payload["temperature"] = temperature
+        if response_format == "json_object":
+            payload["response_format"] = {"type": "json_object"}
+
+        async with httpx.AsyncClient(timeout=self._timeout) as http:
+            response = await http.post(
+                f"{self._base_url}/chat/completions",
+                headers=self._build_headers(),
+                json=payload,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+        choices = data.get("choices") if isinstance(data, dict) else None
+        if not choices:
+            raise ValueError("Provider returned an empty response")
+        message = choices[0].get("message", {})
+        text = message.get("content")
+        if not text and isinstance(message.get("tool_calls"), list):
+            text = json.dumps(message["tool_calls"])  # fallback when JSON mode returns tool calls
+        if not text:
+            raise ValueError("Provider returned an empty response")
+
+        usage = None
+        usage_data = data.get("usage") if isinstance(data, dict) else None
+        if isinstance(usage_data, dict):
+            usage = TokenUsage(
+                prompt_tokens=usage_data.get("prompt_tokens"),
+                completion_tokens=usage_data.get("completion_tokens"),
+                total_tokens=usage_data.get("total_tokens"),
+            )
+
+        return ProviderResponse(text=text, raw=data, usage=usage)
+
+
+class DeepSeekClient(OpenAICompatibleClient):
+    """HTTP client for DeepSeek."""
+
+    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+        super().__init__(
+            base_url=base_url or "https://api.deepseek.com/v1",
+            api_key=api_key,
+        )
+
+
+class GroqClient(OpenAICompatibleClient):
+    """HTTP client for Groq."""
+
+    def __init__(self, *, api_key: str, base_url: str | None = None) -> None:
+        super().__init__(
+            base_url=base_url or "https://api.groq.com/openai/v1",
+            api_key=api_key,
+        )
+
+
+__all__ = [
+    "AnthropicClient",
+    "DeepSeekClient",
+    "GeminiClient",
+    "GroqClient",
+    "LLMClient",
+    "Message",
+    "OllamaClient",
+    "OpenAIClient",
+    "OpenAICompatibleClient",
+    "ProviderResponse",
+    "TokenUsage",
+]
+

--- a/webrenewal/llm/mcp_server.py
+++ b/webrenewal/llm/mcp_server.py
@@ -1,0 +1,201 @@
+"""Model Context Protocol server exposing LLM functionality."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Tuple
+
+import anyio
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp import types
+
+from . import LLMService, create_llm_service, default_model_for, get_tracer, list_available_providers
+
+LOGGER = logging.getLogger("llm.mcp")
+
+
+server = Server(name="webrenewal-llm", instructions="Agentic WebRenewal LLM bridge")
+
+
+def _tool_definition(name: str, description: str, properties: Dict[str, Any]) -> types.Tool:
+    return types.Tool(
+        name=name,
+        description=description,
+        inputSchema={
+            "type": "object",
+            "properties": properties,
+            "required": ["provider", "model", "prompt"],
+        },
+    )
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        _tool_definition(
+            "llm.complete_text",
+            "Generate text using the configured provider.",
+            {
+                "provider": {"type": "string", "description": "LLM provider identifier"},
+                "model": {"type": "string", "description": "Model name"},
+                "prompt": {"type": "string", "description": "User prompt"},
+                "temperature": {
+                    "type": "number",
+                    "description": "Sampling temperature (optional)",
+                },
+            },
+        ),
+        types.Tool(
+            name="llm.complete_json",
+            description="Generate structured JSON via the configured provider.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "provider": {"type": "string"},
+                    "model": {"type": "string"},
+                    "prompt": {"type": "string"},
+                    "schema": {
+                        "type": "string",
+                        "description": "JSON schema definition or instructions",
+                    },
+                    "temperature": {"type": "number"},
+                },
+                "required": ["provider", "model", "prompt"],
+            },
+        ),
+    ]
+
+
+async def _resolve_service(provider: str) -> Tuple[LLMService, str]:
+    service = create_llm_service(provider, tracer=get_tracer())
+    if service is None:
+        raise RuntimeError(f"No credentials configured for provider '{provider}'")
+    return service, default_model_for(provider)
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: Dict[str, Any]):
+    provider = arguments.get("provider")
+    model = arguments.get("model")
+    prompt = arguments.get("prompt")
+    temperature = arguments.get("temperature")
+    schema = arguments.get("schema")
+
+    if not provider or not model or not prompt:
+        return server._make_error_result("provider, model and prompt are required")
+
+    try:
+        service, default_model = await _resolve_service(str(provider))
+        model_name = model or default_model
+        if name == "llm.complete_text":
+            completion = await service.complete_text(
+                prompt,
+                model=model_name,
+                temperature=temperature,
+            )
+            structured = completion.model_dump(mode="json", exclude={"raw"})
+            content = [types.TextContent(type="text", text=completion.text)]
+            return content, structured
+
+        if name == "llm.complete_json":
+            completion = await service.complete_json(
+                prompt,
+                model=model_name,
+                schema=schema,
+                temperature=temperature,
+            )
+            structured = completion.model_dump(mode="json", exclude={"raw"})
+            content = [
+                types.TextContent(
+                    type="text",
+                    text=json.dumps(completion.data, indent=2, ensure_ascii=False),
+                )
+            ]
+            return content, structured
+
+        return server._make_error_result(f"Unknown tool {name}")
+    except Exception as exc:  # pragma: no cover - exercised via integration
+        LOGGER.exception("Tool execution failed")
+        return server._make_error_result(str(exc))
+
+
+@server.list_resources()
+async def list_resources() -> list[types.Resource]:
+    tracer = get_tracer()
+    resources: list[types.Resource] = [
+        types.Resource(
+            uri="llm://providers",
+            mimeType="application/json",
+            description="Available providers and default models",
+        )
+    ]
+
+    seen_last: set[tuple[str, str]] = set()
+    for entry in tracer.list_traces():
+        resources.append(
+            types.Resource(
+                uri=f"llm://trace/{entry.id}",
+                mimeType="application/json",
+                description=f"Trace for {entry.provider}:{entry.model}",
+            )
+        )
+        key = (entry.provider, entry.model)
+        if key not in seen_last:
+            resources.append(
+                types.Resource(
+                    uri=f"llm://last/{entry.provider}/{entry.model}",
+                    mimeType="application/json",
+                    description="Last response for provider/model",
+                )
+            )
+            seen_last.add(key)
+    return resources
+
+
+@server.read_resource()
+async def read_resource(request: types.ReadResourceRequest):
+    uri = request.params.uri
+    tracer = get_tracer()
+
+    if uri == "llm://providers":
+        data = list_available_providers()
+    elif uri.startswith("llm://trace/"):
+        trace_id = uri.split("/", maxsplit=2)[-1]
+        entry = tracer.get_trace(trace_id)
+        if entry is None:
+            return server._make_error_result(f"Trace {trace_id} not found")
+        data = entry.model_dump(mode="json")
+    elif uri.startswith("llm://last/"):
+        _, _, provider, model = uri.split("/", 3)
+        entry = tracer.get_last_trace(provider, model)
+        if entry is None:
+            return server._make_error_result("No trace for provider/model")
+        data = entry.model_dump(mode="json")
+    else:
+        return server._make_error_result(f"Unsupported resource {uri}")
+
+    content = [
+        types.TextContent(
+            type="text",
+            text=json.dumps(data, indent=2, ensure_ascii=False),
+        )
+    ]
+    return types.ServerResult(types.ReadResourceResult(contents=content))
+
+
+async def run() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        options = server.create_initialization_options()
+        await server.run(read_stream, write_stream, options)
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    anyio.run(run)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    main()
+

--- a/webrenewal/llm/models.py
+++ b/webrenewal/llm/models.py
@@ -1,0 +1,154 @@
+"""Pydantic data models used by the LLM integration layer."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Iterable, List, Sequence
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel, model_validator
+
+
+MAX_PREVIEW_CHARS = 800
+
+
+def truncate_preview(value: str, *, limit: int = MAX_PREVIEW_CHARS) -> str:
+    """Return a preview of ``value`` limited to ``limit`` characters."""
+
+    value = value.strip()
+    if len(value) <= limit:
+        return value
+    return value[: limit - 1] + "…"
+
+
+class Message(BaseModel):
+    """A single message sent to an LLM provider."""
+
+    role: str
+    content: str
+
+
+class TokenUsage(BaseModel):
+    """Token usage accounting for a single LLM response."""
+
+    prompt_tokens: int | None = None
+    completion_tokens: int | None = None
+    total_tokens: int | None = None
+
+
+class CompletionMetadata(BaseModel):
+    """Metadata describing a completion call."""
+
+    provider: str
+    model: str
+    duration_ms: float
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    usage: TokenUsage | None = None
+
+
+class BaseCompletion(BaseModel):
+    """Common fields for completion payloads."""
+
+    id: str
+    metadata: CompletionMetadata
+    text: str
+    raw: Any | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True, populate_by_name=True)
+
+
+class JSONPayload(RootModel[Dict[str, Any] | List[Any]]):
+    """Wrapper ensuring JSON payloads are structured data."""
+
+    root: Dict[str, Any] | List[Any]
+
+    @model_validator(mode="after")
+    def _ensure_serialisable(self) -> "JSONPayload":
+        if isinstance(self.root, (dict, list)):
+            return self
+        raise TypeError("JSON payload must be a dict or list")
+
+
+class JSONCompletion(BaseCompletion):
+    """Completion that returned a structured JSON payload."""
+
+    payload: BaseModel | JSONPayload
+
+    @property
+    def data(self) -> Dict[str, Any] | List[Any]:
+        """Return the payload as serialisable data."""
+
+        if isinstance(self.payload, JSONPayload):
+            return self.payload.root
+        return self.payload.model_dump(mode="json")
+
+
+class TextCompletion(BaseCompletion):
+    """Simple text completion."""
+
+
+class TracePrompt(BaseModel):
+    """Representation of the prompt used for a single attempt."""
+
+    messages: Sequence[Message]
+    preview: str
+
+
+class TraceAttempt(BaseModel):
+    """Single attempt when invoking an LLM."""
+
+    attempt: int
+    prompt: TracePrompt
+    response_preview: str | None = None
+    parsed_preview: str | None = None
+    duration_ms: float | None = None
+    usage: TokenUsage | None = None
+    error: str | None = None
+
+
+class LLMTraceEntry(BaseModel):
+    """Full trace of an LLM interaction (possibly with retries)."""
+
+    id: str
+    provider: str
+    model: str
+    started_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    attempts: List[TraceAttempt] = Field(default_factory=list)
+    error: str | None = None
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    def add_attempt(self, attempt: TraceAttempt) -> None:
+        """Append an attempt to the trace entry."""
+
+        self.attempts.append(attempt)
+        if attempt.error:
+            self.error = attempt.error
+        else:
+            self.error = None
+
+    @property
+    def last_attempt(self) -> TraceAttempt | None:
+        """Return the most recent attempt."""
+
+        if not self.attempts:
+            return None
+        return self.attempts[-1]
+
+    @property
+    def prompt_preview(self) -> str:
+        """Return the preview of the first attempt prompt."""
+
+        attempt = self.last_attempt if self.attempts else None
+        if attempt is None:
+            return ""
+        return attempt.prompt.preview
+
+
+def serialise_messages(messages: Iterable[Message]) -> str:
+    """Return a text representation of messages for logging."""
+
+    parts: List[str] = []
+    for message in messages:
+        parts.append(f"{message.role}: {message.content}")
+    return "\n".join(parts)
+

--- a/webrenewal/llm/service.py
+++ b/webrenewal/llm/service.py
@@ -1,0 +1,284 @@
+"""High level orchestration for LLM calls with tracing and validation."""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, MutableMapping, Sequence, Tuple, Type
+
+import jsonschema
+from pydantic import BaseModel, ValidationError
+
+from ..tracing import log_event
+from .clients import LLMClient, ProviderResponse
+from .models import (
+    CompletionMetadata,
+    JSONCompletion,
+    JSONPayload,
+    Message,
+    TextCompletion,
+    truncate_preview,
+)
+from .tracer import LLMTracer, get_tracer
+
+LOGGER = logging.getLogger("llm")
+
+
+MessageType = MutableMapping[str, Any]
+
+
+def _ensure_messages(prompt: Sequence[MessageType] | str) -> List[MessageType]:
+    if isinstance(prompt, str):
+        return [{"role": "user", "content": prompt}]
+    return [dict(message) for message in prompt]
+
+
+def _to_model_messages(messages: Sequence[MessageType]) -> List[Message]:
+    result: List[Message] = []
+    for message in messages:
+        role = str(message.get("role", "user"))
+        content = message.get("content", "")
+        result.append(Message(role=role, content=str(content)))
+    return result
+
+
+def _load_schema(schema: str | Dict[str, Any] | Type[BaseModel] | None) -> Tuple[
+    Dict[str, Any] | None,
+    Type[BaseModel] | None,
+]:
+    if schema is None:
+        return None, None
+    if isinstance(schema, type) and issubclass(schema, BaseModel):
+        return None, schema
+    if isinstance(schema, dict):
+        return schema, None
+    if isinstance(schema, str):
+        try:
+            parsed = json.loads(schema)
+        except json.JSONDecodeError as exc:  # pragma: no cover - invalid schema provided by user
+            raise ValueError("Schema must be valid JSON") from exc
+        if not isinstance(parsed, dict):
+            raise ValueError("Schema JSON must be an object")
+        return parsed, None
+    raise TypeError("Unsupported schema type")
+
+
+class JSONValidationError(RuntimeError):
+    """Raised when JSON parsing or validation fails."""
+
+
+class LLMService:
+    """Wrap a provider client with tracing, retries and validation."""
+
+    def __init__(
+        self,
+        *,
+        provider: str,
+        client: LLMClient,
+        tracer: LLMTracer | None = None,
+    ) -> None:
+        self._provider = provider
+        self._client = client
+        self._tracer = tracer or get_tracer()
+
+    @property
+    def provider(self) -> str:
+        return self._provider
+
+    async def complete_text(
+        self,
+        prompt: Sequence[MessageType] | str,
+        *,
+        model: str,
+        temperature: float | None = None,
+    ) -> TextCompletion:
+        messages = _ensure_messages(prompt)
+        entry = self._tracer.start(self._provider, model)
+        start = time.perf_counter()
+        response: ProviderResponse | None = None
+        error: Exception | None = None
+        try:
+            response = await self._client.complete(
+                messages,
+                model=model,
+                temperature=temperature,
+                response_format=None,
+            )
+            if not response.text or not response.text.strip():
+                raise ValueError("LLM returned an empty response")
+            duration_ms = (time.perf_counter() - start) * 1000
+            usage = response.usage
+            self._tracer.record_attempt(
+                entry,
+                attempt=1,
+                messages=_to_model_messages(messages),
+                response_text=response.text,
+                parsed=None,
+                duration_ms=duration_ms,
+                usage=usage,
+                error=None,
+            )
+            completion = TextCompletion(
+                id=entry.id,
+                text=response.text,
+                raw=response.raw,
+                metadata=CompletionMetadata(
+                    provider=self._provider,
+                    model=model,
+                    duration_ms=round(duration_ms, 2),
+                    usage=usage,
+                ),
+            )
+            self._tracer.record_last_response(self._provider, model, entry.id)
+            log_event(
+                LOGGER,
+                logging.INFO,
+                "llm.complete.text",
+                provider=self._provider,
+                model=model,
+                duration_ms=round(duration_ms, 2),
+                usage=response.usage.model_dump() if response.usage else None,
+                preview=truncate_preview(response.text),
+            )
+            return completion
+        except Exception as exc:  # pragma: no cover - error path validated via tests elsewhere
+            error = exc
+            duration_ms = (time.perf_counter() - start) * 1000
+            self._tracer.record_attempt(
+                entry,
+                attempt=1,
+                messages=_to_model_messages(messages),
+                response_text=response.text if response else None,
+                parsed=None,
+                duration_ms=duration_ms,
+                usage=response.usage if response else None,
+                error=exc,
+            )
+            log_event(
+                LOGGER,
+                logging.ERROR,
+                "llm.complete.text.error",
+                provider=self._provider,
+                model=model,
+                error=repr(exc),
+            )
+            raise
+
+    async def complete_json(
+        self,
+        prompt: Sequence[MessageType] | str,
+        *,
+        model: str,
+        schema: str | Dict[str, Any] | Type[BaseModel] | None = None,
+        temperature: float | None = None,
+        retry_instruction: str | None = None,
+    ) -> JSONCompletion:
+        messages = _ensure_messages(prompt)
+        schema_dict, schema_model = _load_schema(schema)
+        retry_messages = list(messages)
+        attempts = 0
+        entry = self._tracer.start(self._provider, model)
+        last_error: Exception | None = None
+        while attempts < 2:
+            attempts += 1
+            start = time.perf_counter()
+            response: ProviderResponse | None = None
+            error: Exception | None = None
+            parsed_payload: Any | None = None
+            try:
+                response = await self._client.complete(
+                    retry_messages,
+                    model=model,
+                    temperature=temperature,
+                    response_format="json_object",
+                )
+                parsed_payload = json.loads(response.text)
+                if schema_dict is not None:
+                    jsonschema.validate(instance=parsed_payload, schema=schema_dict)
+                    payload_model: BaseModel = JSONPayload(root=parsed_payload)
+                elif schema_model is not None:
+                    payload_model = schema_model.model_validate(parsed_payload)
+                else:
+                    payload_model = JSONPayload(root=parsed_payload)
+
+                duration_ms = (time.perf_counter() - start) * 1000
+                usage = response.usage
+                self._tracer.record_attempt(
+                    entry,
+                    attempt=attempts,
+                    messages=_to_model_messages(retry_messages),
+                    response_text=response.text,
+                    parsed=payload_model.model_dump(mode="json"),
+                    duration_ms=duration_ms,
+                    usage=usage,
+                    error=None,
+                )
+                completion = JSONCompletion(
+                    id=entry.id,
+                    text=response.text,
+                    payload=payload_model,
+                    raw=response.raw,
+                    metadata=CompletionMetadata(
+                        provider=self._provider,
+                        model=model,
+                        duration_ms=round(duration_ms, 2),
+                        usage=usage,
+                    ),
+                )
+                self._tracer.record_last_response(self._provider, model, entry.id)
+                log_event(
+                    LOGGER,
+                    logging.INFO,
+                    "llm.complete.json",
+                    provider=self._provider,
+                    model=model,
+                    duration_ms=round(duration_ms, 2),
+                    usage=usage.model_dump() if usage else None,
+                    preview=truncate_preview(response.text),
+                )
+                return completion
+            except Exception as exc:
+                error = exc
+                duration_ms = (time.perf_counter() - start) * 1000
+                self._tracer.record_attempt(
+                    entry,
+                    attempt=attempts,
+                    messages=_to_model_messages(retry_messages),
+                    response_text=response.text if response else None,
+                    parsed=parsed_payload,
+                    duration_ms=duration_ms,
+                    usage=response.usage if response else None,
+                    error=exc,
+                )
+                log_event(
+                    LOGGER,
+                    logging.WARNING,
+                    "llm.complete.json.retry",
+                    provider=self._provider,
+                    model=model,
+                    attempt=attempts,
+                    error=repr(exc),
+                )
+                if not isinstance(
+                    exc, (json.JSONDecodeError, jsonschema.ValidationError, ValidationError)
+                ):
+                    raise
+                last_error = exc
+                if attempts >= 2:
+                    break
+                retry_messages = list(messages) + [
+                    {
+                        "role": "system",
+                        "content": retry_instruction
+                        or "Return valid JSON only, matching the provided schema exactly.",
+                    }
+                ]
+
+        raise JSONValidationError(
+            f"Failed to parse JSON response from {self._provider}:{model}: {last_error}"
+        )
+
+
+__all__ = ["JSONValidationError", "LLMService"]
+

--- a/webrenewal/llm/tracer.py
+++ b/webrenewal/llm/tracer.py
@@ -1,0 +1,149 @@
+"""Tracing utilities dedicated to LLM interactions."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from typing import Any, List, MutableMapping, Sequence
+
+from pydantic import BaseModel
+
+from ..tracing import log_event, safe_json
+from .models import (
+    LLMTraceEntry,
+    Message,
+    TokenUsage,
+    TraceAttempt,
+    TracePrompt,
+    truncate_preview,
+)
+
+LOGGER = logging.getLogger("llm")
+
+
+class LLMTraceStore(BaseModel):
+    """Simple in-memory store for trace entries."""
+
+    entries: MutableMapping[str, LLMTraceEntry]
+    order: List[str]
+    last_responses: MutableMapping[tuple[str, str], str]
+
+
+class LLMTracer:
+    """Collect trace information for LLM calls."""
+
+    def __init__(self, *, max_entries: int = 200) -> None:
+        self._max_entries = max_entries
+        self._lock = threading.Lock()
+        self._store = LLMTraceStore(entries={}, order=[], last_responses={})
+
+    def start(self, provider: str, model: str) -> LLMTraceEntry:
+        """Create a new trace entry and return it."""
+
+        with self._lock:
+            entry_id = uuid.uuid4().hex
+            entry = LLMTraceEntry(id=entry_id, provider=provider, model=model)
+            self._store.entries[entry_id] = entry
+            self._store.order.append(entry_id)
+            if len(self._store.order) > self._max_entries:
+                oldest = self._store.order.pop(0)
+                self._store.entries.pop(oldest, None)
+            log_event(
+                LOGGER,
+                logging.INFO,
+                "llm.trace.start",
+                id=entry_id,
+                provider=provider,
+                model=model,
+            )
+            return entry
+
+    def record_attempt(
+        self,
+        entry: LLMTraceEntry,
+        *,
+        attempt: int,
+        messages: Sequence[Message],
+        response_text: str | None,
+        parsed: Any | None,
+        duration_ms: float,
+        usage: TokenUsage | None,
+        error: Exception | None,
+    ) -> None:
+        """Append attempt details to an entry."""
+
+        prompt_preview = truncate_preview("\n".join(f"{m.role}: {m.content}" for m in messages))
+        parsed_preview = None
+        if parsed is not None:
+            parsed_preview = truncate_preview(str(safe_json(parsed)))
+
+        attempt_entry = TraceAttempt(
+            attempt=attempt,
+            prompt=TracePrompt(messages=list(messages), preview=prompt_preview),
+            response_preview=truncate_preview(response_text or "") if response_text else None,
+            parsed_preview=parsed_preview,
+            duration_ms=round(duration_ms, 2),
+            usage=usage,
+            error=repr(error) if error else None,
+        )
+
+        with self._lock:
+            entry.add_attempt(attempt_entry)
+            log_event(
+                LOGGER,
+                logging.INFO,
+                "llm.trace.attempt",
+                id=entry.id,
+                attempt=attempt,
+                provider=entry.provider,
+                model=entry.model,
+                duration_ms=round(duration_ms, 2),
+                error=repr(error) if error else None,
+                usage=safe_json(usage.model_dump() if usage else None),
+                prompt_preview=prompt_preview,
+                response_preview=attempt_entry.response_preview,
+                parsed_preview=parsed_preview,
+            )
+
+    def record_last_response(self, provider: str, model: str, trace_id: str) -> None:
+        """Remember the last response id for the provider/model tuple."""
+
+        with self._lock:
+            self._store.last_responses[(provider, model)] = trace_id
+
+    def get_last_trace(self, provider: str, model: str) -> LLMTraceEntry | None:
+        """Return the last trace entry for a provider/model tuple."""
+
+        with self._lock:
+            trace_id = self._store.last_responses.get((provider, model))
+            if not trace_id:
+                return None
+            return self._store.entries.get(trace_id)
+
+    def get_trace(self, trace_id: str) -> LLMTraceEntry | None:
+        """Return a specific trace entry by id."""
+
+        with self._lock:
+            return self._store.entries.get(trace_id)
+
+    def list_traces(self) -> List[LLMTraceEntry]:
+        """Return traces in chronological order."""
+
+        with self._lock:
+            return [self._store.entries[trace_id] for trace_id in self._store.order]
+
+
+_GLOBAL_TRACER: LLMTracer | None = None
+_TRACER_LOCK = threading.Lock()
+
+
+def get_tracer() -> LLMTracer:
+    """Return the process wide tracer instance."""
+
+    global _GLOBAL_TRACER
+    with _TRACER_LOCK:
+        if _GLOBAL_TRACER is None:
+            _GLOBAL_TRACER = LLMTracer()
+        return _GLOBAL_TRACER
+

--- a/webrenewal/pipeline.py
+++ b/webrenewal/pipeline.py
@@ -29,7 +29,7 @@ from .agents import (
     ToolDiscoveryAgent,
 )
 from .agents.base import Agent
-from .llm import BaseLLMClient, create_llm_client, default_model_for
+from .llm import LLMService, create_llm_service, default_model_for, get_tracer
 from .models import (
     A11yReport,
     ContentBundle,
@@ -62,7 +62,9 @@ class WebRenewalPipeline:
         self.logger = logger or logging.getLogger("pipeline")
         self.config = config or load_pipeline_config()
         self._llm_provider = llm_provider
-        self._llm_client: BaseLLMClient | None = create_llm_client(llm_provider)
+        self._llm_client: LLMService | None = create_llm_service(
+            llm_provider, tracer=get_tracer()
+        )
         resolved_model = llm_model or default_model_for(llm_provider)
         self._llm_model = resolved_model
         if self._llm_client is None:


### PR DESCRIPTION
## Summary
- refactor the LLM integration into a service plus tracer with provider clients, JSON schema validation, and additional providers
- expose text and JSON completion tooling plus trace resources via an MCP server and update CLI/docs for new provider options
- add comprehensive unit coverage for LLM edge cases and rewrite agent interactions with structured payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd1efe1748832d82a528195dbded75