### PR TITLE
Fix MCP URIs and improve JSON mode handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,20 @@ Ressourcen:
 - `llm://last/{provider}/{model}` – letzter Completion-Output
 - `llm://trace/{id}` – vollständiger Trace inklusive Retries und Token-Nutzung
 
+Die URIs orientieren sich an den MCP-Konventionen: `llm://trace/{id}` liefert den Trace
+zum exakten Identifier (z. B. `llm://trace/abc123` → Trace `abc123`). Über
+`llm://last/{provider}/{model}` wird der zuletzt gespeicherte Trace für das Paar aus
+Provider und Modell geladen (z. B. `llm://last/openai/gpt-4o`).
+
 Die Antworten sind strukturierte Pydantic-Modelle. Fehlgeschlagene JSON-Parsings führen
 zu einem zweiten Versuch mit strengeren Instruktionen; bei erneutem Fehlschlag wird der
 Trace persistiert und eine aussagekräftige Fehlermeldung ausgelöst.
+
+`llm.complete_json` nutzt – je nach Provider – entweder den nativen JSON-Mode (falls vom
+Client unterstützt) oder erzwingt über einen System-Prompt eine strikt valide JSON-Ausgabe.
+Bei Parsing- oder Validierungsfehlern wird automatisch mit einer verstärkten Instruktion
+erneut versucht, bevor ein Fehler propagiert wird. Sämtliche Aufrufe werden mit Prompt,
+Rohantwort und Metadaten im Trace-Log festgehalten.
 
 Alle Artefakte landen in `sandbox/`, inklusive Crawl-Daten, Analysen, Plan, Rewrite,
 Theming-Tokens, einer vollständigen Kopie der Originalseiten (`sandbox/original/`),

--- a/tests/unit/test_mcp_server.py
+++ b/tests/unit/test_mcp_server.py
@@ -1,0 +1,108 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from webrenewal.llm import mcp_server
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class StubTraceEntry:
+    def __init__(self, *, entry_id: str, provider: str = "stub", model: str = "model") -> None:
+        self.id = entry_id
+        self.provider = provider
+        self.model = model
+
+    def model_dump(self, *, mode: str = "json"):
+        return {"id": self.id, "provider": self.provider, "model": self.model}
+
+
+class StubTracer:
+    def __init__(self) -> None:
+        self.trace_lookup: dict[str, StubTraceEntry] = {}
+        self.last_lookup: dict[tuple[str, str], StubTraceEntry] = {}
+        self.requested_trace_id: str | None = None
+        self.requested_last: tuple[str, str] | None = None
+
+    def list_traces(self):
+        return []
+
+    def get_trace(self, trace_id: str):
+        self.requested_trace_id = trace_id
+        return self.trace_lookup.get(trace_id)
+
+    def get_last_trace(self, provider: str, model: str):
+        self.requested_last = (provider, model)
+        return self.last_lookup.get((provider, model))
+
+
+@pytest.mark.anyio
+async def test_read_resource_trace_uses_clean_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = StubTracer()
+    tracer.trace_lookup["abc"] = StubTraceEntry(entry_id="abc")
+    monkeypatch.setattr(mcp_server, "get_tracer", lambda: tracer)
+
+    request = SimpleNamespace(params=SimpleNamespace(uri="llm://trace/abc"))
+    result = await mcp_server.read_resource(request)
+
+    assert tracer.requested_trace_id == "abc"
+    payload = json.loads(result.root.contents[0].text)
+    assert payload["id"] == "abc"
+
+
+@pytest.mark.anyio
+async def test_read_resource_last_parses_provider_and_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = StubTracer()
+    tracer.last_lookup[("openai", "gpt-4o")] = StubTraceEntry(
+        entry_id="xyz", provider="openai", model="gpt-4o"
+    )
+    monkeypatch.setattr(mcp_server, "get_tracer", lambda: tracer)
+
+    request = SimpleNamespace(params=SimpleNamespace(uri="llm://last/openai/gpt-4o"))
+    result = await mcp_server.read_resource(request)
+
+    assert tracer.requested_last == ("openai", "gpt-4o")
+    payload = json.loads(result.root.contents[0].text)
+    assert payload["id"] == "xyz"
+
+
+@pytest.mark.anyio
+async def test_read_resource_trace_missing_identifier(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = StubTracer()
+    monkeypatch.setattr(mcp_server, "get_tracer", lambda: tracer)
+    captured: dict[str, str] = {}
+
+    def fake_error(message: str):
+        captured["message"] = message
+        return message
+
+    monkeypatch.setattr(mcp_server.server, "_make_error_result", fake_error)
+
+    request = SimpleNamespace(params=SimpleNamespace(uri="llm://trace/"))
+    result = await mcp_server.read_resource(request)
+
+    assert result == "Trace id missing"
+    assert captured["message"] == "Trace id missing"
+
+
+@pytest.mark.anyio
+async def test_read_resource_last_invalid_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    tracer = StubTracer()
+    monkeypatch.setattr(mcp_server, "get_tracer", lambda: tracer)
+    captured: dict[str, str] = {}
+
+    def fake_error(message: str):
+        captured["message"] = message
+        return message
+
+    monkeypatch.setattr(mcp_server.server, "_make_error_result", fake_error)
+
+    request = SimpleNamespace(params=SimpleNamespace(uri="llm://last/openai"))
+    result = await mcp_server.read_resource(request)
+
+    assert result == "Invalid last trace URI"
+    assert captured["message"] == "Invalid last trace URI"

--- a/webrenewal/llm/clients.py
+++ b/webrenewal/llm/clients.py
@@ -40,6 +40,12 @@ class ProviderResponse:
 class LLMClient(abc.ABC):
     """Interface for provider specific clients."""
 
+    @property
+    def supports_json_mode(self) -> bool:
+        """Return whether the client can request native JSON mode."""
+
+        return False
+
     async def complete(
         self,
         messages: Sequence[MessagePayload],
@@ -294,11 +300,17 @@ class OpenAICompatibleClient(LLMClient):
         api_key: str,
         timeout: float = 60.0,
         headers: Optional[Dict[str, str]] = None,
+        supports_json_mode: bool = True,
     ) -> None:
         self._base_url = base_url.rstrip("/")
         self._api_key = api_key
         self._timeout = timeout
         self._headers = headers or {}
+        self._supports_json_mode = supports_json_mode
+
+    @property
+    def supports_json_mode(self) -> bool:
+        return self._supports_json_mode
 
     def _build_headers(self) -> Dict[str, str]:
         headers = {"Authorization": f"Bearer {self._api_key}", "Content-Type": "application/json"}
@@ -361,6 +373,7 @@ class DeepSeekClient(OpenAICompatibleClient):
         super().__init__(
             base_url=base_url or "https://api.deepseek.com/v1",
             api_key=api_key,
+            supports_json_mode=False,
         )
 
 
@@ -371,6 +384,7 @@ class GroqClient(OpenAICompatibleClient):
         super().__init__(
             base_url=base_url or "https://api.groq.com/openai/v1",
             api_key=api_key,
+            supports_json_mode=False,
         )
 
 


### PR DESCRIPTION
## Summary
- fix MCP resource parsing for trace and last URIs and return structured resource payloads
- add client capability flags for JSON mode with system prompt fallbacks and richer tracing/logging
- document MCP URI usage and JSON handling while adding unit tests for JSON retries and MCP resources

## Testing
- pytest tests/unit/test_llm.py tests/unit/test_mcp_server.py

------
https://chatgpt.com/codex/tasks/task_e_68dd24f7fd6c832db8d5ec75d9f73a99