### PR TITLE
Add renewal configuration model and mode-aware pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Die Pipeline unterstützt mehrere Provider. Ohne weitere Parameter wird OpenAI m
 | Groq      | `GROQ_API_KEY` | `GROQ_BASE_URL`, `GROQ_MODEL` |
 | Ollama    | – (lokaler Dienst) | `OLLAMA_HOST`, `OLLAMA_MODEL` |
 
+Neben Provider und Modell können nun auch **Renewal-Mode**, **CSS-Framework** und eine freie **Theme-Style**-Beschreibung angegeben werden.
+
+| Option | Beschreibung |
+|--------|--------------|
+| `--renewal-mode {full,text-only,seo-only,design-only}` | Steuert, welche Agenten laufen: `full` aktiviert alle Schritte, `text-only` führt nur das Rewrite (A11) aus, `design-only` überspringt den Rewrite und fokussiert auf Theming/Build, `seo-only` liefert ausschließlich SEO/Metadata-Optimierungen. |
+| `--css-framework <name>` | Beliebiger Framework-/Library-Name. Bekannte Werte wie `bootstrap`, `tailwind` oder `vanilla` verwenden hinterlegte Templates, unbekannte Werte werden als Custom-Framework in Theming/Builder weitergereicht. |
+| `--theme-style "…"` | Komma-separierte Stilhinweise (Farben, Formen, Effekte, Typografie). Diese Hinweise landen direkt beim Theming- und Builder-Agenten. |
+
 Beispiele für den CLI-Aufruf (Modell optional, ansonsten greift der Default pro Provider):
 
 ```bash
@@ -187,11 +195,28 @@ python renewal.py https://www.physioheld.ch --llm deepseek --llm-model deepseek-
 
 # Groq
 python renewal.py https://www.physioheld.ch --llm groq --llm-model llama3-70b-8192
+
+# Text-Only Optimierung
+python renewal.py https://www.physioheld.ch --renewal-mode text-only --theme-style "klar, sachlich"
+
+# Design-Refresh ohne Copy-Änderungen
+python renewal.py https://www.physioheld.ch --renewal-mode design-only --css-framework material --theme-style "modern, blue/white, rounded buttons, shadow"
+
+# SEO-Fokus
+python renewal.py https://www.physioheld.ch --renewal-mode seo-only --theme-style ""
 ```
 
 Alle Artefakte landen in `sandbox/`, inklusive Crawl-Daten, Analysen, Plan, Rewrite,
 Theming-Tokens, einer vollständigen Kopie der Originalseiten (`sandbox/original/`),
 dem mehrseitigen Build (`sandbox/newsite/`), Diff-Preview und Angebot.
+
+Zusätzlich wird die komplette CLI-Konfiguration als `sandbox/config.json` abgelegt, so dass spätere API-Calls die gleichen Settings übernehmen können.
+
+**Erweiterungstipps:**
+
+* Neue Frameworks lassen sich über `--css-framework` direkt anfragen. Soll ein Preset ergänzt werden, kann in `BuilderAgent` eine passende CDN-Konfiguration hinterlegt werden.
+* Stilhinweise funktionieren am besten als kurze Komma-Liste: Farben („modern blue/white“), Formen („rounded buttons“), Effekte („shadow, glassmorphism“) oder Typografie („serif, elegant“).
+* Eigene Renewal-Modes können durch eine Erweiterung des `RenewalConfig`-Schemas sowie der Modusschalter in `WebRenewalPipeline` ergänzt werden.
 
 ### MCP Server für LLMs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "anthropic>=0.34.0",
     "jsonschema>=4.21.1",
     "mcp>=1.15.0",
+    "pydantic>=2.7.0",
 ]
 
 [project.scripts]

--- a/renewal.py
+++ b/renewal.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import argparse
-import logging
 import os
 
 from dotenv import load_dotenv
+
+from webrenewal.models import RenewalConfig
 from webrenewal.pipeline import run_pipeline
 
 
@@ -19,10 +20,20 @@ def parse_args() -> argparse.Namespace:
         help="Python logging level (default: INFO)",
     )
     parser.add_argument(
+        "--renewal-mode",
+        default="full",
+        choices=["full", "text-only", "seo-only", "design-only"],
+        help="Select which parts of the pipeline should run.",
+    )
+    parser.add_argument(
         "--css-framework",
         default="vanilla",
-        choices=["bootstrap", "tailwind", "vanilla"],
-        help="Select the CSS framework used for generated templates.",
+        help="Name of the CSS framework or design system to target.",
+    )
+    parser.add_argument(
+        "--theme-style",
+        default="",
+        help="Comma separated style hints (colours, shapes, effects).",
     )
     parser.add_argument(
         "--llm",
@@ -41,14 +52,16 @@ def parse_args() -> argparse.Namespace:
 def main() -> None:
     load_dotenv()
     args = parse_args()
-    log_level = getattr(logging, args.log_level.upper(), logging.INFO)
-    run_pipeline(
-        args.domain,
-        log_level=log_level,
+    config = RenewalConfig(
+        domain=args.domain,
+        renewal_mode=args.renewal_mode,
         css_framework=args.css_framework,
+        theme_style=args.theme_style,
         llm_provider=args.llm,
         llm_model=args.llm_model,
+        log_level=args.log_level,
     )
+    run_pipeline(config)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ httpx>=0.27.0
 anthropic>=0.34.0
 jsonschema>=4.21.1
 mcp>=1.15.0
+pydantic>=2.7.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -216,7 +216,7 @@ def sample_content_bundle(sample_content_extract: ContentExtract) -> ContentBund
 def sample_preview_index() -> PreviewIndex:
     """Return a preview index with one diff entry."""
 
-    return PreviewIndex(diffs=[])
+    return PreviewIndex(diffs=[], style_deltas=[])
 
 
 @pytest.fixture

--- a/tests/integration/test_pipeline_integration.py
+++ b/tests/integration/test_pipeline_integration.py
@@ -20,6 +20,7 @@ from webrenewal.agents.tech_fingerprint import TechFingerprintAgent
 from webrenewal.agents.tool_discovery import ToolDiscoveryAgent
 from webrenewal.models import ContentBundle, ContentBlock
 from webrenewal.pipeline import WebRenewalPipeline
+from webrenewal.models import RenewalConfig
 
 
 class StaticAgent:
@@ -79,7 +80,16 @@ def test_pipeline_creates_expected_artifacts(
 
     logger = logging.getLogger("pipeline-integration")
     logger.setLevel(logging.CRITICAL)
-    pipeline = WebRenewalPipeline(logger=logger, css_framework="vanilla", llm_provider="openai")
+    config = RenewalConfig(
+        domain="https://example.com",
+        renewal_mode="full",
+        css_framework="vanilla",
+        theme_style="",
+        llm_provider="openai",
+        llm_model=None,
+        log_level="CRITICAL",
+    )
+    pipeline = WebRenewalPipeline(renewal_config=config, logger=logger)
 
     pipeline.tool_discovery = StaticAgent("A0.ToolDiscovery", prepared_outputs["tool_catalog"])
     pipeline.scope = StaticAgent("A1.Scope", prepared_outputs["scope_plan"])
@@ -96,7 +106,7 @@ def test_pipeline_creates_expected_artifacts(
     pipeline.theming = StaticAgent("A12.Theming", prepared_outputs["theme"])
     # keep builder/comparator/offer/memory agents to exercise real behaviour
 
-    pipeline.execute("https://example.com")
+    pipeline.execute()
 
     artifacts = {path.name for path in sandbox_dir.iterdir() if path.is_file()}
     expected_files = {

--- a/tests/unit/agents/test_builder_agent.py
+++ b/tests/unit/agents/test_builder_agent.py
@@ -52,9 +52,11 @@ def test_builder_agent_generates_unique_slugs(builder_agent: BuilderAgent, sampl
     assert len(set(page_files)) == len(page_files)
 
 
-def test_builder_agent_rejects_unknown_framework() -> None:
-    """Given an invalid framework When constructing Then a ValueError is raised."""
+def test_builder_agent_supports_custom_framework() -> None:
+    """Given a custom framework When constructing Then metadata reflects the request."""
 
-    with pytest.raises(ValueError):
-        BuilderAgent(css_framework="unknown")
+    agent = BuilderAgent(css_framework="custom-xyz", style_hints="rounded buttons")
+
+    assert agent._framework_meta["is_custom"] is True  # type: ignore[attr-defined]
+    assert agent._framework_meta["style_hints"] == "rounded buttons"  # type: ignore[attr-defined]
 

--- a/tests/unit/agents/test_offer_agent.py
+++ b/tests/unit/agents/test_offer_agent.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from webrenewal.agents.offer import OfferAgent
-from webrenewal.models import PreviewIndex, RenewalPlan
+from webrenewal.models import DiffResult, PreviewIndex, RenewalPlan
 
 
 def test_offer_agent_generates_summary(sample_plan, sample_preview_index) -> None:
@@ -22,7 +22,7 @@ def test_offer_agent_enforces_minimum_price(sample_plan) -> None:
 
     low_plan = RenewalPlan(goals=[], actions=[], estimate_hours=2)
     agent = OfferAgent()
-    preview = PreviewIndex(diffs=[object()])
+    preview = PreviewIndex(diffs=[DiffResult(page="/", diff="")])
     offer = agent.run(("example.com", low_plan, preview))
 
     assert offer.pricing_eur == 600.0

--- a/tests/unit/test_pipeline.py
+++ b/tests/unit/test_pipeline.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from webrenewal.models import CrawlResult, PageContent
+from webrenewal.models import CrawlResult, PageContent, RenewalConfig
 from webrenewal.pipeline import WebRenewalPipeline
 
 
@@ -17,7 +17,16 @@ def pipeline(monkeypatch: pytest.MonkeyPatch, sandbox_dir: Path) -> WebRenewalPi
 
     logger = logging.getLogger("pipeline-test")
     logger.setLevel(logging.CRITICAL)
-    return WebRenewalPipeline(logger=logger)
+    config = RenewalConfig(
+        domain="https://example.com",
+        renewal_mode="full",
+        css_framework="vanilla",
+        theme_style="",
+        llm_provider="openai",
+        llm_model=None,
+        log_level="CRITICAL",
+    )
+    return WebRenewalPipeline(renewal_config=config, logger=logger)
 
 
 def test_summarise_output_handles_model(pipeline: WebRenewalPipeline) -> None:

--- a/tests/unit/test_pipeline_modes.py
+++ b/tests/unit/test_pipeline_modes.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+import pytest
+
+from webrenewal.models import (
+    A11yReport,
+    BuildArtifact,
+    ContentBlock,
+    ContentBundle,
+    ContentExtract,
+    ContentSection,
+    CrawlResult,
+    DiffResult,
+    MediaReport,
+    MemoryRecord,
+    NavModel,
+    NavigationItem,
+    OfferDoc,
+    PageContent,
+    PreviewIndex,
+    RenewalAction,
+    RenewalPlan,
+    ScopePlan,
+    SEOReport,
+    SecurityReport,
+    ThemeTokens,
+    ToolCatalog,
+    ToolInfo,
+    RenewalConfig,
+    TechFingerprint,
+)
+from webrenewal.pipeline import WebRenewalPipeline
+from webrenewal.storage import SANDBOX_DIR
+
+
+def _default_stage_outputs(content_extract: ContentExtract) -> Dict[str, object]:
+    crawl = CrawlResult(pages=[PageContent(url="https://example.com", status_code=200, headers={}, html="<html></html>")])
+    base_theme = ThemeTokens(
+        colors={
+            "primary": "#0b7285",
+            "secondary": "#f1f3f5",
+            "accent": "#ffd43b",
+            "surface": "#ffffff",
+            "surface_alt": "#f8f9fa",
+            "text": "#212529",
+            "muted": "#495057",
+            "border": "#dee2e6",
+        },
+        typography={
+            "body_family": "'Inter', sans-serif",
+            "heading_family": "'Inter', sans-serif",
+            "base_size": "16px",
+            "scale": "1.25",
+            "line_height": "1.6",
+            "heading_weight": "600",
+        },
+        spacing={"xs": "0.25rem", "sm": "0.5rem", "md": "1rem", "lg": "1.5rem", "xl": "2.5rem"},
+        radius={"sm": "0.25rem", "md": "0.5rem", "lg": "0.75rem", "pill": "999px"},
+        breakpoints={"sm": "576px", "md": "768px", "lg": "992px", "xl": "1200px"},
+        elevation={
+            "flat": "0 1px 2px rgba(15, 23, 42, 0.06)",
+            "raised": "0 12px 30px rgba(15, 23, 42, 0.12)",
+            "overlay": "0 24px 60px rgba(15, 23, 42, 0.18)",
+        },
+        slots={},
+    )
+    blocks = [
+        ContentBlock(title=section.title, body=section.text, type="text")
+        for section in content_extract.sections
+    ]
+    return {
+        "tool_catalog": ToolCatalog(
+            tools=[ToolInfo(name="crawler", category="core", description="", usage_snippet="crawl()")]
+        ),
+        "scope": ScopePlan(domain="https://example.com", seed_urls=["https://example.com"], sitemap_urls=[]),
+        "crawl": crawl,
+        "readability": content_extract,
+        "tech": TechFingerprint(frameworks=["django"], evidence={}),
+        "a11y": A11yReport(score=95.0, issues=[]),
+        "seo": SEOReport(score=90.0, issues=[]),
+        "security": SecurityReport(score=88.0, issues=[]),
+        "media": MediaReport(images=[]),
+        "navigation": NavModel(items=[NavigationItem(label="Home", href="index.html")]),
+        "plan": RenewalPlan(goals=["Improve"], actions=[RenewalAction(identifier="a", description="desc", impact="high", effort_hours=2.0)], estimate_hours=2.0),
+        "rewrite": ContentBundle(blocks=blocks, meta_title="Title", meta_description="Desc", fallback_used=False),
+        "theming": base_theme,
+        "build": BuildArtifact(output_dir=str(SANDBOX_DIR / "newsite"), files=[]),
+        "compare": PreviewIndex(diffs=[DiffResult(page="https://example.com", diff="")], style_deltas=["design"]),
+        "offer": OfferDoc(title="Offer", summary="Summary", pricing_eur=600.0),
+        "memory": MemoryRecord(key="example", payload={}),
+    }
+
+
+@pytest.mark.parametrize(
+    "mode,expected_present,expected_absent",
+    [
+        ("full", {"rewrite", "theming", "build", "compare"}, set()),
+        ("text-only", {"rewrite"}, {"theming", "build", "compare"}),
+        ("design-only", {"theming", "build", "compare"}, {"rewrite"}),
+        ("seo-only", set(), {"rewrite", "theming", "build", "compare"}),
+    ],
+)
+def test_pipeline_modes_control_agent_execution(
+    mode: str,
+    expected_present: set[str],
+    expected_absent: set[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logger = logging.getLogger(f"pipeline-{mode}")
+    logger.setLevel(logging.CRITICAL)
+    content_extract = ContentExtract(
+        sections=[ContentSection(title="Intro", text="Body", readability_score=70.0)],
+        language="en",
+    )
+    config = RenewalConfig(
+        domain="https://example.com",
+        renewal_mode=mode,
+        css_framework="custom",
+        theme_style="modern, blue",
+        llm_provider="openai",
+        llm_model=None,
+        log_level="CRITICAL",
+    )
+    pipeline = WebRenewalPipeline(renewal_config=config, logger=logger)
+    outputs = _default_stage_outputs(content_extract)
+    called: list[str] = []
+
+    def _fake_run_agent(self, agent, payload, *, stage: str):
+        called.append(stage)
+        return outputs[stage]
+
+    monkeypatch.setattr(WebRenewalPipeline, "_run_agent", _fake_run_agent)
+
+    pipeline.execute()
+
+    assert expected_present.issubset(set(called))
+    assert not expected_absent.intersection(set(called))


### PR DESCRIPTION
## Summary
- introduce a shared `RenewalConfig` Pydantic model and update the CLI to capture renewal mode, framework, and theme style hints
- propagate the new configuration through the pipeline, gating rewrite/theming/builder steps per mode and persisting run settings
- extend builder, theming, and comparator agents to honour custom frameworks and style directives, and document the new workflow in the README
- add unit coverage for the different renewal modes and adjust existing tests for the new configuration flow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68dd29163f1c832d89b376a43fe58e36