### PR TITLE
Normalize preview payload when skipping builds

### DIFF
--- a/webrenewal/pipeline.py
+++ b/webrenewal/pipeline.py
@@ -86,12 +86,18 @@ class PostEditPipeline:
                 hash=change_hash,
             )
             latest_preview = self.state_store.latest_preview()
+            preview_info = None
+            if latest_preview:
+                preview_info = {
+                    "id": latest_preview.get("id"),
+                    "path": latest_preview.get("index_path"),
+                }
             build_info = None
             if site_state.build.get("latest_dist"):
                 build_info = {"output_dir": site_state.build.get("latest_dist")}
             return {
                 "change_set": change_set.to_dict(),
-                "preview": latest_preview,
+                "preview": preview_info,
                 "build": build_info,
             }
 


### PR DESCRIPTION
## Summary
- normalize the preview payload when the pipeline skips duplicate or empty change sets so clients always receive {id, path}

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd3c075b64832db1ab3e440aa69b3a