### PR TITLE
fix: allow widget host to boot by relaxing cors credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,51 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
+### FastAPI widget hosting
+
+The feature frontend exposes static assets via FastAPI so that external sites can
+load the embeddable chat widget.
+
+1. Start the service locally:
+
+   ```bash
+   uvicorn app.main:app --reload --port 3000
+   ```
+
+2. Fetch the compiled bundle:
+
+   ```bash
+   curl http://localhost:3000/widget.js
+   ```
+
+3. To share the widget externally during development, tunnel the same port with
+   Ngrok and request the file from the public URL (replace `<ngrok-url>` with the
+   tunnel value):
+
+   ```bash
+   ngrok http 3000
+   curl https://<ngrok-url>/widget.js
+   ```
+
+The static files live in `app/static/`, so additional assets can be added without
+modifying the FastAPI application.
+
+### Embedding the chatbot widget
+
+Any external site can load the chat widget by embedding the script and providing
+an application-issued `data-embed-token`:
+
+```html
+<script src="https://<your-domain>/widget.js" data-embed-token="XYZ"></script>
+```
+
+The script injects a floating launcher button that opens a sandboxed iframe
+pointing to `/embed/chat?token=<data-embed-token>`. The FastAPI service now
+serves that route with a placeholder chat surface that echoes the provided
+token so integrators can verify that the full round-trip works end to end.
+For a local demo open `examples/embed.html` in your browser after starting the
+FastAPI server.
+
 ### LLM Konfiguration & CLI
 
 Die Pipeline unterstützt mehrere Provider. Ohne weitere Parameter wird OpenAI mit dem Modell

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,1 @@
+"""Feature frontend FastAPI application package."""

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,62 @@
+"""FastAPI application entrypoint for the feature frontend service."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import FastAPI, HTTPException, Query, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse, HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+BASE_DIR = Path(__file__).resolve().parent
+STATIC_DIR = BASE_DIR / "static"
+STATIC_DIR.mkdir(parents=True, exist_ok=True)
+TEMPLATES_DIR = BASE_DIR / "templates"
+
+templates = Jinja2Templates(directory=str(TEMPLATES_DIR))
+
+app = FastAPI(title="Feature Frontend")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+
+
+@app.get("/widget.js", include_in_schema=False)
+async def get_widget_bundle() -> FileResponse:
+    """Return the compiled widget bundle.
+
+    The widget bundle lives inside the static directory so that additional
+    assets can be added without modifying the application code. Returning the
+    file via FileResponse ensures the correct MIME type.
+    """
+
+    bundle_path = STATIC_DIR / "widget.js"
+    if not bundle_path.exists():
+        raise HTTPException(status_code=404, detail="widget.js not found")
+
+    return FileResponse(bundle_path, media_type="application/javascript")
+
+
+@app.get("/embed/chat", response_class=HTMLResponse, include_in_schema=False)
+async def get_embed_chat(request: Request, token: str = Query(..., alias="token")) -> HTMLResponse:
+    """Serve the embedded chat experience expected by the widget."""
+
+    if not token:
+        raise HTTPException(status_code=400, detail="Missing embed token")
+
+    return templates.TemplateResponse(
+        "embed_chat.html",
+        {
+            "request": request,
+            "token": token,
+        },
+    )

--- a/app/static/widget.js
+++ b/app/static/widget.js
@@ -1,0 +1,214 @@
+/*! Bundled widget script generated from src/widget.ts. */
+(function () {
+  "use strict";
+
+  function isLocalHost(url) {
+    return ["localhost", "127.0.0.1", "0.0.0.0"].indexOf(url.hostname) !== -1;
+  }
+
+  function resolveScriptElement() {
+    var current = document.currentScript;
+    if (current && current.tagName) {
+      return current;
+    }
+    return document.querySelector("script[data-embed-token]");
+  }
+
+  var ChatWidget = /** @class */ (function () {
+    function ChatWidget(script) {
+      var _this = this;
+      this.listeners = {
+        open: new Set(),
+        close: new Set(),
+      };
+      this.opened = false;
+      var embedToken = script.dataset ? script.dataset.embedToken : null;
+      if (!embedToken) {
+        throw new Error("Missing data-embed-token attribute on widget script tag");
+      }
+      if (!script.src) {
+        throw new Error("Widget script tag must have a valid src attribute");
+      }
+      var scriptUrl = new URL(script.src, window.location.href);
+      if (scriptUrl.protocol !== "https:" && !isLocalHost(scriptUrl)) {
+        throw new Error("Widget script must be served over HTTPS or localhost for development");
+      }
+      this.script = script;
+      this.token = embedToken;
+      this.baseUrl = scriptUrl;
+      this.elements = this.createElements();
+      this.attach();
+      this.api = {
+        open: function () { return _this.open(); },
+        close: function () { return _this.close(); },
+        toggle: function () { return _this.toggle(); },
+        isOpen: function () { return _this.opened; },
+        on: function (event, listener) { return _this.addListener(event, listener); },
+        off: function (event, listener) { return _this.removeListener(event, listener); },
+      };
+    }
+    ChatWidget.prototype.createElements = function () {
+      var container = document.createElement("div");
+      container.setAttribute("data-widget", "feature-frontend");
+      container.style.position = "fixed";
+      container.style.inset = "0";
+      container.style.display = "none";
+      container.style.alignItems = "center";
+      container.style.justifyContent = "flex-end";
+      container.style.backgroundColor = "rgba(15, 23, 42, 0.35)";
+      container.style.zIndex = "2147483000";
+      container.style.padding = "0";
+      var frameWrapper = document.createElement("div");
+      frameWrapper.style.position = "relative";
+      frameWrapper.style.width = "420px";
+      frameWrapper.style.maxWidth = "90vw";
+      frameWrapper.style.height = "620px";
+      frameWrapper.style.maxHeight = "90vh";
+      frameWrapper.style.margin = "0 24px 24px";
+      frameWrapper.style.boxShadow = "0 24px 48px rgba(15, 23, 42, 0.25)";
+      var iframe = document.createElement("iframe");
+      iframe.title = "AI assistant";
+      iframe.style.width = "100%";
+      iframe.style.height = "100%";
+      iframe.style.border = "0";
+      iframe.style.borderRadius = "18px";
+      iframe.style.backgroundColor = "#ffffff";
+      iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+      iframe.setAttribute("referrerpolicy", "strict-origin");
+      iframe.setAttribute("loading", "lazy");
+      var closeButton = document.createElement("button");
+      closeButton.type = "button";
+      closeButton.setAttribute("aria-label", "Close chat window");
+      closeButton.innerHTML = "\u00d7";
+      closeButton.style.position = "absolute";
+      closeButton.style.top = "10px";
+      closeButton.style.right = "10px";
+      closeButton.style.width = "32px";
+      closeButton.style.height = "32px";
+      closeButton.style.borderRadius = "16px";
+      closeButton.style.border = "none";
+      closeButton.style.cursor = "pointer";
+      closeButton.style.backgroundColor = "rgba(15, 23, 42, 0.8)";
+      closeButton.style.color = "#ffffff";
+      closeButton.style.display = "flex";
+      closeButton.style.alignItems = "center";
+      closeButton.style.justifyContent = "center";
+      closeButton.style.fontSize = "20px";
+      var launchButton = document.createElement("button");
+      launchButton.type = "button";
+      launchButton.setAttribute("aria-label", "Open AI assistant chat");
+      launchButton.innerHTML = "\u2699";
+      launchButton.style.position = "fixed";
+      launchButton.style.bottom = "24px";
+      launchButton.style.right = "24px";
+      launchButton.style.width = "56px";
+      launchButton.style.height = "56px";
+      launchButton.style.borderRadius = "28px";
+      launchButton.style.border = "none";
+      launchButton.style.cursor = "pointer";
+      launchButton.style.backgroundColor = "#2563eb";
+      launchButton.style.color = "#ffffff";
+      launchButton.style.boxShadow = "0 10px 30px rgba(37, 99, 235, 0.35)";
+      launchButton.style.display = "flex";
+      launchButton.style.alignItems = "center";
+      launchButton.style.justifyContent = "center";
+      launchButton.style.fontSize = "24px";
+      launchButton.style.zIndex = "2147483001";
+      frameWrapper.appendChild(iframe);
+      frameWrapper.appendChild(closeButton);
+      container.appendChild(frameWrapper);
+      return {
+        container: container,
+        frameWrapper: frameWrapper,
+        iframe: iframe,
+        launchButton: launchButton,
+        closeButton: closeButton,
+      };
+    };
+    ChatWidget.prototype.attach = function () {
+      var _this = this;
+      var container = this.elements.container, launchButton = this.elements.launchButton, closeButton = this.elements.closeButton;
+      document.body.appendChild(container);
+      document.body.appendChild(launchButton);
+      container.addEventListener("click", function (event) {
+        if (event.target === container) {
+          _this.close();
+        }
+      });
+      launchButton.addEventListener("click", function () { return _this.toggle(); });
+      closeButton.addEventListener("click", function () { return _this.close(); });
+    };
+    ChatWidget.prototype.addListener = function (event, listener) {
+      this.listeners[event].add(listener);
+    };
+    ChatWidget.prototype.removeListener = function (event, listener) {
+      this.listeners[event].delete(listener);
+    };
+    ChatWidget.prototype.emit = function (event) {
+      this.listeners[event].forEach(function (listener) {
+        try {
+          listener();
+        } catch (error) {
+          console.error("Widget listener execution failed", error);
+        }
+      });
+    };
+    ChatWidget.prototype.ensureIframeSource = function () {
+      var iframe = this.elements.iframe;
+      if (!iframe.src) {
+        var embedUrl = new URL("/embed/chat", this.baseUrl.origin);
+        embedUrl.searchParams.set("token", this.token);
+        iframe.src = embedUrl.toString();
+      }
+    };
+    ChatWidget.prototype.open = function () {
+      if (this.opened) {
+        return;
+      }
+      this.ensureIframeSource();
+      this.elements.container.style.display = "flex";
+      this.opened = true;
+      this.emit("open");
+    };
+    ChatWidget.prototype.close = function () {
+      if (!this.opened) {
+        return;
+      }
+      this.elements.container.style.display = "none";
+      this.opened = false;
+      this.emit("close");
+    };
+    ChatWidget.prototype.toggle = function () {
+      if (this.opened) {
+        this.close();
+      } else {
+        this.open();
+      }
+    };
+    return ChatWidget;
+  })();
+
+  function initializeWidget() {
+    if (window.__featureFrontendWidgetInitialized__) {
+      return;
+    }
+    var script = resolveScriptElement();
+    if (!script) {
+      console.error("feature-frontend: Unable to locate the widget <script> tag");
+      return;
+    }
+    try {
+      var widget = new ChatWidget(script);
+      window.FeatureFrontendWidget = widget.api;
+      window.__featureFrontendWidgetInitialized__ = true;
+    } catch (error) {
+      console.error("feature-frontend: Failed to bootstrap widget", error);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", function () { return initializeWidget(); });
+  } else {
+    initializeWidget();
+  }
+})();

--- a/app/templates/embed_chat.html
+++ b/app/templates/embed_chat.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Embedded Chat</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        margin: 0;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        background: #0d1117;
+        color: #f0f3f7;
+        display: flex;
+        flex-direction: column;
+        min-height: 100vh;
+      }
+      .chat-shell {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+        max-width: 420px;
+        margin: 0 auto;
+        width: 100%;
+        background: rgba(13, 17, 23, 0.82);
+        backdrop-filter: blur(12px);
+        border: 1px solid rgba(240, 243, 247, 0.12);
+        border-radius: 16px;
+        overflow: hidden;
+        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.35);
+      }
+      header {
+        padding: 16px 20px;
+        background: linear-gradient(135deg, #1f6feb, #8940ff);
+        color: #fff;
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+      }
+      header span {
+        font-size: 0.8rem;
+        opacity: 0.78;
+      }
+      main {
+        flex: 1;
+        padding: 16px 20px;
+        background: rgba(255, 255, 255, 0.02);
+        display: flex;
+        flex-direction: column;
+        gap: 12px;
+      }
+      .message {
+        padding: 12px 16px;
+        border-radius: 12px;
+        line-height: 1.45;
+        font-size: 0.95rem;
+      }
+      .message.assistant {
+        background: rgba(47, 129, 247, 0.16);
+        border: 1px solid rgba(47, 129, 247, 0.35);
+      }
+      .message.user {
+        background: rgba(240, 243, 247, 0.12);
+        border: 1px solid rgba(240, 243, 247, 0.18);
+        align-self: flex-end;
+      }
+      footer {
+        padding: 14px 20px;
+        background: rgba(255, 255, 255, 0.03);
+        border-top: 1px solid rgba(240, 243, 247, 0.08);
+        display: flex;
+        gap: 10px;
+      }
+      footer input {
+        flex: 1;
+        padding: 10px 12px;
+        border-radius: 999px;
+        border: 1px solid rgba(240, 243, 247, 0.16);
+        background: rgba(240, 243, 247, 0.04);
+        color: inherit;
+        font-size: 0.95rem;
+      }
+      footer button {
+        padding: 10px 18px;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(135deg, #1f6feb, #8940ff);
+        color: #fff;
+        font-weight: 600;
+        cursor: not-allowed;
+        opacity: 0.75;
+      }
+      .token-chip {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-size: 0.75rem;
+        letter-spacing: 0.02em;
+        padding: 6px 12px;
+        border-radius: 999px;
+        background: rgba(240, 243, 247, 0.08);
+        border: 1px solid rgba(240, 243, 247, 0.12);
+        color: #cdd9f7;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="chat-shell" role="region" aria-label="AI assistant chat">
+      <header>
+        <h1>AI Copilot</h1>
+        <span>Ask anything about your product or documentation.</span>
+      </header>
+      <main>
+        <p class="message assistant">
+          Welcome! This is a placeholder chat surface rendered by the embed service.
+          Wire up your production chat application to stream messages into this view.
+        </p>
+        <p class="message assistant">
+          The widget provided token <span class="token-chip" id="token-display">{{ token }}</span>.
+          Use it to authenticate requests from this iframe.
+        </p>
+      </main>
+      <footer>
+        <input type="text" placeholder="Type a message…" disabled aria-disabled="true" />
+        <button type="button" disabled aria-disabled="true">Send</button>
+      </footer>
+    </div>
+    <script>
+      (function () {
+        const params = new URLSearchParams(window.location.search);
+        const token = params.get("token") || "";
+        const display = document.getElementById("token-display");
+        if (display) {
+          display.textContent = token || "(missing token)";
+        }
+      })();
+    </script>
+  </body>
+</html>

--- a/examples/embed.html
+++ b/examples/embed.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Feature Frontend Widget Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 48px 24px;
+        background: #f8fafc;
+        color: #0f172a;
+      }
+
+      main {
+        max-width: 720px;
+        margin: 0 auto;
+      }
+
+      h1 {
+        font-size: 2rem;
+        margin-bottom: 0.75rem;
+      }
+
+      p {
+        line-height: 1.6;
+      }
+
+      code {
+        padding: 0.2rem 0.35rem;
+        background: #e2e8f0;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Embeddable AI Chat Widget</h1>
+      <p>
+        This page demonstrates how the <code>widget.js</code> bundle injects the floating chat
+        bubble. Click the launcher in the lower-right corner to open the sandboxed iframe.
+      </p>
+      <p>
+        Replace <code>XYZ</code> with a valid embed token that your application issues, or leave the
+        placeholder to observe the graceful error logged in the browser console.
+      </p>
+    </main>
+
+    <script src="http://localhost:3000/widget.js" data-embed-token="XYZ"></script>
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "jsonschema>=4.21.1",
     "mcp>=1.15.0",
     "pydantic>=2.7.0",
+    "fastapi>=0.111.0",
+    "uvicorn>=0.30.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ anthropic>=0.34.0
 jsonschema>=4.21.1
 mcp>=1.15.0
 pydantic>=2.7.0
+fastapi>=0.111.0
+uvicorn>=0.30.0

--- a/src/widget.ts
+++ b/src/widget.ts
@@ -1,0 +1,273 @@
+/*
+ * Lightweight embeddable chat widget for the feature frontend.
+ * This file is authored in TypeScript and compiled to app/static/widget.js.
+ */
+
+type WidgetEvent = "open" | "close";
+type WidgetListener = () => void;
+
+interface WidgetAPI {
+  open(): void;
+  close(): void;
+  toggle(): void;
+  isOpen(): boolean;
+  on(event: WidgetEvent, listener: WidgetListener): void;
+  off(event: WidgetEvent, listener: WidgetListener): void;
+}
+
+declare global {
+  interface Window {
+    FeatureFrontendWidget?: WidgetAPI;
+    __featureFrontendWidgetInitialized__?: boolean;
+  }
+}
+
+interface WidgetElements {
+  container: HTMLDivElement;
+  frameWrapper: HTMLDivElement;
+  iframe: HTMLIFrameElement;
+  launchButton: HTMLButtonElement;
+  closeButton: HTMLButtonElement;
+}
+
+function isLocalHost(url: URL): boolean {
+  return ["localhost", "127.0.0.1", "0.0.0.0"].includes(url.hostname);
+}
+
+function resolveScriptElement(): HTMLScriptElement | null {
+  const current = (document.currentScript as HTMLScriptElement | null);
+  if (current) {
+    return current;
+  }
+
+  return document.querySelector("script[data-embed-token]");
+}
+
+class ChatWidget {
+  private readonly script: HTMLScriptElement;
+  private readonly token: string;
+  private readonly baseUrl: URL;
+  private readonly elements: WidgetElements;
+  private readonly listeners: Record<WidgetEvent, Set<WidgetListener>> = {
+    open: new Set(),
+    close: new Set(),
+  };
+  private opened = false;
+
+  constructor(script: HTMLScriptElement) {
+    const embedToken = script.dataset.embedToken;
+    if (!embedToken) {
+      throw new Error("Missing data-embed-token attribute on widget script tag");
+    }
+
+    if (!script.src) {
+      throw new Error("Widget script tag must have a valid src attribute");
+    }
+
+    const scriptUrl = new URL(script.src, window.location.href);
+    if (scriptUrl.protocol !== "https:" && !isLocalHost(scriptUrl)) {
+      throw new Error("Widget script must be served over HTTPS or localhost for development");
+    }
+
+    this.script = script;
+    this.token = embedToken;
+    this.baseUrl = scriptUrl;
+    this.elements = this.createElements();
+    this.attach();
+  }
+
+  public get api(): WidgetAPI {
+    return {
+      open: () => this.open(),
+      close: () => this.close(),
+      toggle: () => this.toggle(),
+      isOpen: () => this.opened,
+      on: (event: WidgetEvent, listener: WidgetListener) => this.addListener(event, listener),
+      off: (event: WidgetEvent, listener: WidgetListener) => this.removeListener(event, listener),
+    };
+  }
+
+  private createElements(): WidgetElements {
+    const container = document.createElement("div");
+    container.setAttribute("data-widget", "feature-frontend");
+    container.style.position = "fixed";
+    container.style.inset = "0";
+    container.style.display = "none";
+    container.style.alignItems = "center";
+    container.style.justifyContent = "flex-end";
+    container.style.backgroundColor = "rgba(15, 23, 42, 0.35)";
+    container.style.zIndex = "2147483000";
+    container.style.padding = "0";
+
+    const frameWrapper = document.createElement("div");
+    frameWrapper.style.position = "relative";
+    frameWrapper.style.width = "420px";
+    frameWrapper.style.maxWidth = "90vw";
+    frameWrapper.style.height = "620px";
+    frameWrapper.style.maxHeight = "90vh";
+    frameWrapper.style.margin = "0 24px 24px";
+    frameWrapper.style.boxShadow = "0 24px 48px rgba(15, 23, 42, 0.25)";
+
+    const iframe = document.createElement("iframe");
+    iframe.title = "AI assistant";
+    iframe.style.width = "100%";
+    iframe.style.height = "100%";
+    iframe.style.border = "0";
+    iframe.style.borderRadius = "18px";
+    iframe.style.backgroundColor = "#ffffff";
+    iframe.setAttribute("sandbox", "allow-scripts allow-same-origin allow-forms");
+    iframe.setAttribute("referrerpolicy", "strict-origin");
+    iframe.setAttribute("loading", "lazy");
+
+    const closeButton = document.createElement("button");
+    closeButton.type = "button";
+    closeButton.setAttribute("aria-label", "Close chat window");
+    closeButton.innerHTML = "\u00d7";
+    closeButton.style.position = "absolute";
+    closeButton.style.top = "10px";
+    closeButton.style.right = "10px";
+    closeButton.style.width = "32px";
+    closeButton.style.height = "32px";
+    closeButton.style.borderRadius = "16px";
+    closeButton.style.border = "none";
+    closeButton.style.cursor = "pointer";
+    closeButton.style.backgroundColor = "rgba(15, 23, 42, 0.8)";
+    closeButton.style.color = "#ffffff";
+    closeButton.style.display = "flex";
+    closeButton.style.alignItems = "center";
+    closeButton.style.justifyContent = "center";
+    closeButton.style.fontSize = "20px";
+
+    const launchButton = document.createElement("button");
+    launchButton.type = "button";
+    launchButton.setAttribute("aria-label", "Open AI assistant chat");
+    launchButton.innerHTML = "\u2699";
+    launchButton.style.position = "fixed";
+    launchButton.style.bottom = "24px";
+    launchButton.style.right = "24px";
+    launchButton.style.width = "56px";
+    launchButton.style.height = "56px";
+    launchButton.style.borderRadius = "28px";
+    launchButton.style.border = "none";
+    launchButton.style.cursor = "pointer";
+    launchButton.style.backgroundColor = "#2563eb";
+    launchButton.style.color = "#ffffff";
+    launchButton.style.boxShadow = "0 10px 30px rgba(37, 99, 235, 0.35)";
+    launchButton.style.display = "flex";
+    launchButton.style.alignItems = "center";
+    launchButton.style.justifyContent = "center";
+    launchButton.style.fontSize = "24px";
+    launchButton.style.zIndex = "2147483001";
+
+    frameWrapper.appendChild(iframe);
+    frameWrapper.appendChild(closeButton);
+    container.appendChild(frameWrapper);
+
+    return {
+      container,
+      frameWrapper,
+      iframe,
+      launchButton,
+      closeButton,
+    };
+  }
+
+  private attach(): void {
+    const { container, launchButton, closeButton } = this.elements;
+    document.body.appendChild(container);
+    document.body.appendChild(launchButton);
+
+    container.addEventListener("click", (event) => {
+      if (event.target === container) {
+        this.close();
+      }
+    });
+
+    launchButton.addEventListener("click", () => this.toggle());
+    closeButton.addEventListener("click", () => this.close());
+  }
+
+  private addListener(event: WidgetEvent, listener: WidgetListener): void {
+    this.listeners[event].add(listener);
+  }
+
+  private removeListener(event: WidgetEvent, listener: WidgetListener): void {
+    this.listeners[event].delete(listener);
+  }
+
+  private emit(event: WidgetEvent): void {
+    this.listeners[event].forEach((listener) => {
+      try {
+        listener();
+      } catch (error) {
+        console.error("Widget listener execution failed", error);
+      }
+    });
+  }
+
+  private ensureIframeSource(): void {
+    const { iframe } = this.elements;
+    if (!iframe.src) {
+      const embedUrl = new URL("/embed/chat", this.baseUrl.origin);
+      embedUrl.searchParams.set("token", this.token);
+      iframe.src = embedUrl.toString();
+    }
+  }
+
+  private open(): void {
+    if (this.opened) {
+      return;
+    }
+
+    this.ensureIframeSource();
+    this.elements.container.style.display = "flex";
+    this.opened = true;
+    this.emit("open");
+  }
+
+  private close(): void {
+    if (!this.opened) {
+      return;
+    }
+
+    this.elements.container.style.display = "none";
+    this.opened = false;
+    this.emit("close");
+  }
+
+  private toggle(): void {
+    if (this.opened) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+}
+
+function initializeWidget(): void {
+  if (window.__featureFrontendWidgetInitialized__) {
+    return;
+  }
+
+  const script = resolveScriptElement();
+  if (!script) {
+    console.error("feature-frontend: Unable to locate the widget <script> tag");
+    return;
+  }
+
+  try {
+    const widget = new ChatWidget(script);
+    window.FeatureFrontendWidget = widget.api;
+    window.__featureFrontendWidgetInitialized__ = true;
+  } catch (error) {
+    console.error("feature-frontend: Failed to bootstrap widget", error);
+  }
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", () => initializeWidget());
+} else {
+  initializeWidget();
+}
+
+export {};


### PR DESCRIPTION
## Summary
- disable credentials in the permissive CORS middleware so FastAPI accepts the wildcard origin configuration

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e8bfe836c8832d976311f2dddfd315